### PR TITLE
Stop force pushing for deployments

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "watch": "gulp watch",
     "docs": "mkdir -p core/static && npm run build -s && NODE_ENV=development node --harmony ./docs/index.js",
     "shrinkwrap": "npm shrinkwrap --dev",
-    "deploy": "git push -f origin master:deploy/production"
+    "deploy": "git push origin master:deploy/production"
   },
   "devDependencies": {
     "babel": "^6.3.26",


### PR DESCRIPTION
As part of our move to protected branches. Shouldn't make a difference for the starter kit itself, but it's good to keep it as close as possible to real world projects.