### PR TITLE
Front-end launch checklist upgrade

### DIFF
--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -1,0 +1,188 @@
+# Frontend project launch checklist
+
+**:warning: To understand how this is meant to be used,have a look at [the complete launch checklist](launch-checklist.md).**
+
+### Code quality
+
+- [ ] Clean up commented/unnecessary code.
+- [ ] Check all TODO comments are still relevant.
+- [ ] Debugging console logs and breakpoints removed.
+
+####  CSS
+
+- [ ] CSS code matches the code style guide via `npm run lint`.
+- [ ] [CSS validation](http://jigsaw.w3.org/css-validator/) passes.
+- [ ] CSS classes use a consistent naming methodology (BEM).
+- [ ] Flexbox usage has a non-flexbox fallback if appropriate.
+- [ ] Sass code is free of vendor prefixes and IE filters.
+- [x] TODO – CSS specificity graph is flat :rainbow:.
+- [x] TODO – Print stylesheets exist if appropriate.
+- [ ] Site does not use `-webkit-font-rendering: antialised;` for body copy.
+
+#### JS
+
+- [ ] JS code matches the code style guide via `npm run lint`.
+- [ ] JS code is written in ES6.
+- [ ] Data attributes are used to select elements, not classes or ids or tags.
+- [ ] Polyfills are included if appropriate (Respond.js, `fetch`, `babel-polyfill`, etc).
+
+#### HTML
+
+- [ ] Ensure all `a` tags have an href attribute.
+- [ ] Use absolute paths for all URLS. `/thing/` not `thing/`.
+- [ ] Use HTTPS, or exclude protocol from URLs `//foo.com/` not `http://foo.com/`.
+- [ ] [HTML validation](https://validator.w3.org/nu/#textarea) passes.
+- [ ] Links do not use `target="_blank"`, or use [`rel="noopener`](https://mathiasbynens.github.io/rel-noopener/) if they need to.
+
+#### Images
+
+- [ ] Images use the right file format (SVG if possible, PNG for graphics, JPG for pictures).
+- [ ] All images with the `img` tag define `width` and `height` attributes to prevent content reflows when the images load.
+- [ ] Icons are built using [SVG icons](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/icon.html), with appropriate fallback if necessary.
+- [ ] All of the images are [losslessly optimized with ImageOptim](https://imageoptim.com/).
+
+### Functional completeness
+
+- [ ] 404 page exists and is styled.
+- [ ] 500 page exists and is styled.
+- [ ] Maintenance page exists and is styled, if relevant.
+- [ ] Site uses a mobile-friendly, zoomable viewport.
+- [ ] Site has a favicon.ico.
+- [ ] Platform-specific ([Apple](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html), Android, Windows, etc) meta tags and favicons are added and checked with the [Favicon checker](https://realfavicongenerator.net/favicon_checker).
+- [ ] Ensure meta tags, Open Graph tags, Twitter card tags, and descriptions are set.
+- [ ] Ensure the social meta tags only use a default sharing image if there is no page-specific image to use.
+- [ ] Google Search Console / Webmaster Tools is configured on the project.
+- [ ] Long-running actions (AJAX calls) trigger a spinner or other loading message in the UI.
+- [ ] UI text uses correct typographic marks (`’` instead of `'`, `“”` instead of `""`).
+- [ ] Significant UI states (tabs, modals, etc) should be tracked in the URL via query parameter or the hash.
+
+### Forms
+
+- [ ] Form fields use the right [input types with the right mobile keyboard](http://baymard.com/labs/touch-keyboard-types).
+- [ ] Form fields have their [`name`, `autocomplete` and `autocorrect` attributes](https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete) set correctly.
+- [ ] Forms never trust client-side input, ensure it is valid.
+- [ ] Prompt the user before navigating away from unsaved changes.
+- [ ] Always re-populate fields when a user hits 'back', by using cache-control: private.
+- [ ] Multi-step forms save data after each step.
+
+#### Form validation and errors
+
+- [ ] Forms use server-side validation, and client-side validation if relevant.
+- [ ] Forms do not use HTML5 validation. No `required`. Field `type`, `maxlength` and other consistent improvements that do not need to display validation messages are ok. `minlength` isn't.
+- [ ] Form errors are cleared when people change a field's value.
+- [ ] Forms display non-field errors at the top of the form.
+- [ ] If there are no non-field errors, still display a message, eg “Sorry, there were some errors” at the top of the form.
+- [ ] Forms use CSRF tokens when they mutate state (POST/PUT/DELETE, eg. editing a user/booking/listing’s data).
+
+#### Search
+
+- [ ] Use GETs with query strings for all kinds of searches (as query strings can be easily bookmarked).
+
+### Build systems
+
+- [ ] Use [Pleeease/Autoprefixer](http://pleeease.io) for all styles.
+- [ ] No compiled code in the `master` branch.
+- [ ] JS development aids are removed in production.
+- [ ] Source maps are removed in production.
+- [ ] SVG icons are compressed in production.
+
+### Testing
+
+- [ ] Site is visually tested on non-retina, low contrast screens.
+- [ ] Relevant unit tests are written.
+- [ ] Unit tests pass (`npm run test:unit`).
+- [ ] Relevant integration tests are written.
+- [ ] Integration tests pass (`npm run test:integration`).
+- [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
+- [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support) (including IE if relevant).
+- [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
+- [ ] Run site url through the Facebook debugger (https://developers.facebook.com/tools/debug/) to check it will appear correctly if shared.
+- [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink).
+- [ ] Spelling and grammar checked thoroughly (copy/paste the site's content in Google Docs, or better yet get someone else on the team or from the client to do it for you).
+
+### Performance
+
+- [ ] All static assets (CSS, JS, SVG, JSON) are minified and concatenated in production.
+- [x] TODO - Single pages are less than the allocated performance budget (unless there's a very good reason not to).
+- [ ] Run through [Google PageSpeed](https://developers.google.com/speed/pagespeed/), [GTmetrix](https://gtmetrix.com/).
+- [ ] Use [SpeedCurve](https://speedcurve.com) to configure the performance monitoring on the site's most important page (homepage?).
+- [x] TODO – Critical CSS is extracted and inlined in the HTML file if relevant.
+- [ ] Web fonts should be kept to a minimum (talk with designers).
+- [ ] Subset webfonts to remove unused characters (http://www.subsetter.com/, https://github.com/miguelsousa/source-sans-pro-subset).
+- [ ] Font files are available in WOFF, WOFF2, and EOT/OTF if relevant (IE8 / Android Stock Browser).
+- [ ] Static files are cache-busted with a query parameter (eg. `?v=4hjk54j6`) in production (JS/CSS/etc).
+
+#### Server configuration
+
+- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with PageSpeed or GTmetrix).
+- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with PageSpeed or GTmetrix).
+- [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`).
+
+### Deployment
+
+- [ ] The project is [`shrinkwrapped`](https://github.com/springload/frontend-starter-kit/#adding-and-upgrading-dependencies) to pin its dependencies.
+- [ ] The build service / CI is using `NODE_ENV=production` for compilation tasks.
+- [ ] No unnecessary files (`node_modules`) are sent to the production server, slowing down the build (look for the list of files sent to the server in the `rsync` step of the deployment).
+- [ ] CI runs the CI tests (`npm run test:ci`, or `npm run test`), and the build breaks if they fail.
+- [ ] CI builds trigger notifications in the appropriate Slack channel.
+
+### Semantics
+
+- [ ] Relevant site sections use appropriate [schema.org](http://schema.org/) structured data (events, products, persons, etc), tested with https://search.google.com/structured-data/testing-tool.
+
+### SEO
+
+- [ ] Link to sitemap `<link rel=”sitemap” type=”application/xml” title=”Sitemap” href=”/sitemap.xml”>”`.
+- [ ] Sitemap content is relevant.
+- [ ] Help pagination with rel=”next” and rel=”prev” tag.
+- [ ] robots.txt is here.
+- [ ] humans.txt is here (forbidden in robots.txt).
+
+### Analytics
+
+- [ ] Google Tag Manager or Google Analytics are loaded on all pages (but not both).
+- [ ] Check analytics are configured in development with a development property.
+- [ ] Check analytics are configured in production with the production property.
+- [ ] Check the relevant client-side interactions are tracked with events.
+- [ ] If relevant, client-side JS errors are logged as [exceptions](https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions).
+- [ ] Page and event tracking is being displayed correctly in the GA dashboard.
+
+### Accessibility
+
+- [ ] Roles are assigned to basic site sections.
+header - `role="banner"`, main content - `role="main"`, footer - `role="contentinfo"`
+- [ ] All images must have appropriate alt tags - extra great if you include all text that appears eg English and Māori translation text in a lot of company logos in NZ. [empty `alt=""` can be appropriate](http://osric.com/chris/accidental-developer/2012/01/when-should-alt-text-be-blank/).
+- [ ] If relevant, icons include an accessible label with the `<title>` SVG tag.
+- [ ] `<html>` element has attribute `lang="en-nz"`.
+- [ ] If you have used outline: 0 anywhere make sure you have called the tab focus function in utils js file or any other alternative style for focus state.
+- [ ] Screen reader only text for links with images/icons only.
+- [ ] Form fields are inside the label element.
+- [ ] Form error messages should be inside label element.
+- [ ] All toggle content should have aria controls and expanded states.
+- [ ] Most important content and pages are tested for color-blindness and vision disorders with http://lowvision.support/.
+- [ ] Body copy and visuals have enough contrast according to WCAG guidelines https://leaverou.github.io/contrast-ratio/.
+
+### Documentation
+
+- [ ] The code documents itself via function names and variable names.
+- [ ] The code contains comments to explain its intent where appropriate.
+
+#### The README contains
+
+- [ ] Continuous integration service badge for the project (CodeShip).
+- [ ] A table of important links, with:
+- [ ] Stage and Live site links.
+- [ ] Links to Trello board, Harvest project, project run sheet, Drive folder.
+- [ ] Links to design resources - Zeplin, InVision, other.
+- [ ] Analytics and montoring URLs.
+- [ ] Links to other important documents and services.
+- [ ] Project installation instructions.
+- [ ] Project development commands.
+- [ ] Test commands.
+- [ ] Deployment commands.
+- [ ] [Browser support definition](https://github.com/springload/frontend-starter-kit#browser-support).
+- [ ] The project's useful patterns to reuse.
+- [ ] Debugging tricks.
+- [ ] Testing data.
+
+You made it to the end! Whoo, high five my friend :pray:! Now go treat yourself to a drink :tropical_drink:, a hug :hugging_face:, or whatever floats your boat :rainbow:. Don’t forget to let your team know that you’ve got this under control, and be proud of that top-notch site you just built. :metal:

--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -87,13 +87,13 @@
 
 ### Testing
 
+- [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support).
 - [ ] Site is visually tested on non-retina, low contrast screens.
 - [ ] Relevant unit tests are written.
 - [ ] Unit tests pass (`npm run test:unit`).
 - [ ] Relevant integration tests are written.
 - [ ] Integration tests pass (`npm run test:integration`).
 - [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
-- [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support) (including IE if relevant).
 - [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
 - [ ] Run site url through the Facebook debugger (https://developers.facebook.com/tools/debug/) to check it will appear correctly if shared.
 - [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink).
@@ -134,7 +134,7 @@
 
 ### Accessibility
 
-- [ ] Roles are assigned to basic site sections.
+- [ ] Roles (ARIA landmarks) are assigned to basic site sections.
 header - `role="banner"`, main content - `role="main"`, footer - `role="contentinfo"`
 - [ ] All images must have appropriate alt tags - extra great if you include all text that appears eg English and Māori translation text in a lot of company logos in NZ. [empty `alt=""` can be appropriate](http://osric.com/chris/accidental-developer/2012/01/when-should-alt-text-be-blank/).
 - [ ] If relevant, icons include an accessible label with the `<title>` SVG tag.

--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -111,7 +111,7 @@
 
 ### Performance
 
-- [ ] The site has a score above 90 in [Google PageSpeed](https://developers.google.com/speed/pagespeed/) and [GTmetrix](https://gtmetrix.com/).
+- [ ] The live site has a score above 90 in [Google PageSpeed](https://developers.google.com/speed/pagespeed/) and [GTmetrix](https://gtmetrix.com/).
 - [ ] Web fonts should be kept to a minimum (talk with designers).
 - [ ] Subset webfonts to remove unused characters (http://www.subsetter.com/, https://github.com/miguelsousa/source-sans-pro-subset).
 - [ ] Font files are available in WOFF, WOFF2, and EOT/OTF if relevant (IE8 / Android Stock Browser).
@@ -137,7 +137,7 @@
 
 - [ ] Google Tag Manager or Google Analytics are loaded on all pages (but not both).
 - [ ] Check analytics are configured in development with a development property.
-- [ ] Check analytics are configured in production with the production property.
+- [ ] Check analytics are configured in production with the production property on the live site.
 - [ ] Check the relevant client-side interactions are tracked with events.
 - [ ] If relevant, client-side JS errors are logged as [exceptions](https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions).
 - [ ] Page and event tracking is being displayed correctly in the GA dashboard.

--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -5,7 +5,7 @@
 ### Code quality
 
 - [ ] Clean up commented/unnecessary code.
-- [ ] Check all TODO comments are still relevant.
+- [ ] Check all TODO comments in the code are still relevant.
 - [ ] Debugging console logs and breakpoints removed.
 
 ####  CSS
@@ -32,14 +32,14 @@
 - [ ] Use absolute paths for all URLS. `/thing/` not `thing/`.
 - [ ] Use HTTPS, or exclude protocol from URLs `//foo.com/` not `http://foo.com/`.
 - [ ] [HTML validation](https://validator.w3.org/nu/#textarea) passes.
-- [ ] Links do not use `target="_blank"`, or use [`rel="noopener`](https://mathiasbynens.github.io/rel-noopener/) if they need to.
+- [ ] Links with `target="_blank"` use [`rel="noopener`](https://mathiasbynens.github.io/rel-noopener/).
+- [ ] Links from user-submitted (untrusted) content use [`rel="nofollow`](https://support.google.com/webmasters/answer/96569)
 
-#### Images
+### Images
 
 - [ ] Images use the right file format (SVG if possible, PNG for graphics, JPG for pictures).
 - [ ] All images with the `img` tag define `width` and `height` attributes to prevent content reflows when the images load.
 - [ ] Icons are built using [SVG icons](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/icon.html), with appropriate fallback if necessary.
-- [ ] All of the images are [losslessly optimized with ImageOptim](https://imageoptim.com/).
 
 ### Functional completeness
 
@@ -51,7 +51,6 @@
 - [ ] Platform-specific ([Apple](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html), Android, Windows, etc) meta tags and favicons are added and checked with the [Favicon checker](https://realfavicongenerator.net/favicon_checker).
 - [ ] Ensure meta tags, Open Graph tags, Twitter card tags, and descriptions are set.
 - [ ] Ensure the social meta tags only use a default sharing image if there is no page-specific image to use.
-- [ ] Google Search Console / Webmaster Tools is configured on the project.
 - [ ] Long-running actions (AJAX calls) trigger a spinner or other loading message in the UI.
 - [ ] UI text uses correct typographic marks (`’` instead of `'`, `“”` instead of `""`).
 - [ ] Significant UI states (tabs, modals, etc) should be tracked in the URL via query parameter or the hash.
@@ -98,33 +97,23 @@
 - [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
 - [ ] Run site url through the Facebook debugger (https://developers.facebook.com/tools/debug/) to check it will appear correctly if shared.
 - [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink).
-- [ ] Spelling and grammar checked thoroughly (copy/paste the site's content in Google Docs, or better yet get someone else on the team or from the client to do it for you).
 
 ### Performance
 
 - [ ] All static assets (CSS, JS, SVG, JSON) are minified and concatenated in production.
 - [x] TODO - Single pages are less than the allocated performance budget (unless there's a very good reason not to).
 - [ ] Run through [Google PageSpeed](https://developers.google.com/speed/pagespeed/), [GTmetrix](https://gtmetrix.com/).
-- [ ] Use [SpeedCurve](https://speedcurve.com) to configure the performance monitoring on the site's most important page (homepage?).
 - [x] TODO – Critical CSS is extracted and inlined in the HTML file if relevant.
 - [ ] Web fonts should be kept to a minimum (talk with designers).
 - [ ] Subset webfonts to remove unused characters (http://www.subsetter.com/, https://github.com/miguelsousa/source-sans-pro-subset).
 - [ ] Font files are available in WOFF, WOFF2, and EOT/OTF if relevant (IE8 / Android Stock Browser).
 - [ ] Static files are cache-busted with a query parameter (eg. `?v=4hjk54j6`) in production (JS/CSS/etc).
 
-#### Server configuration
-
-- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with PageSpeed or GTmetrix).
-- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with PageSpeed or GTmetrix).
-- [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`).
-
 ### Deployment
 
 - [ ] The project is [`shrinkwrapped`](https://github.com/springload/frontend-starter-kit/#adding-and-upgrading-dependencies) to pin its dependencies.
 - [ ] The build service / CI is using `NODE_ENV=production` for compilation tasks.
-- [ ] No unnecessary files (`node_modules`) are sent to the production server, slowing down the build (look for the list of files sent to the server in the `rsync` step of the deployment).
 - [ ] CI runs the CI tests (`npm run test:ci`, or `npm run test`), and the build breaks if they fail.
-- [ ] CI builds trigger notifications in the appropriate Slack channel.
 
 ### Semantics
 
@@ -132,11 +121,7 @@
 
 ### SEO
 
-- [ ] Link to sitemap `<link rel=”sitemap” type=”application/xml” title=”Sitemap” href=”/sitemap.xml”>”`.
-- [ ] Sitemap content is relevant.
-- [ ] Help pagination with rel=”next” and rel=”prev” tag.
-- [ ] robots.txt is here.
-- [ ] humans.txt is here (forbidden in robots.txt).
+- [ ] Help pagination with `rel=”next”` and `rel=”prev”` attributes.
 
 ### Analytics
 
@@ -169,13 +154,6 @@ header - `role="banner"`, main content - `role="main"`, footer - `role="contenti
 
 #### The README contains
 
-- [ ] Continuous integration service badge for the project (CodeShip).
-- [ ] A table of important links, with:
-- [ ] Stage and Live site links.
-- [ ] Links to Trello board, Harvest project, project run sheet, Drive folder.
-- [ ] Links to design resources - Zeplin, InVision, other.
-- [ ] Analytics and montoring URLs.
-- [ ] Links to other important documents and services.
 - [ ] Project installation instructions.
 - [ ] Project development commands.
 - [ ] Test commands.
@@ -185,4 +163,4 @@ header - `role="banner"`, main content - `role="main"`, footer - `role="contenti
 - [ ] Debugging tricks.
 - [ ] Testing data.
 
-You made it to the end! Whoo, high five my friend :pray:! Now go treat yourself to a drink :tropical_drink:, a hug :hugging_face:, or whatever floats your boat :rainbow:. Don’t forget to let your team know that you’ve got this under control, and be proud of that top-notch site you just built. :metal:
+You made it to the end! Whoo, high five my friend :pray:! Now go treat yourself to a drink :tropical_drink:, a hug, or whatever floats your waka :rainbow:. Don’t forget to let your team know that you’ve got this under control, and be proud of that top-notch site you just built. :metal:

--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -79,40 +79,50 @@
 
 ### Build systems
 
+- [ ] No compiled code in the `master` branch (check the project's `.gitignore` file to make sure no `static/`, `dist/` files are committed in.
+
+#### Gulp asset pipeline configuration
+
 - [ ] Use [Pleeease/Autoprefixer](http://pleeease.io) for all styles.
-- [ ] No compiled code in the `master` branch.
+- [ ] SVG icons are compressed in production.
+- [ ] CSS & SVG is minified and concatenated in production.
+
+#### Webpack / Browserify configuration
+
 - [ ] JS development aids are removed in production.
 - [ ] Source maps are removed in production.
-- [ ] SVG icons are compressed in production.
+- [ ] JS is minified and concatenated in production.
 
 ### Testing
 
 - [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support).
 - [ ] Site is visually tested on non-retina, low contrast screens.
+- [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
+- [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
+
+#### Automated tests
+
 - [ ] Relevant unit tests are written.
 - [ ] Unit tests pass (`npm run test:unit`).
 - [ ] Relevant integration tests are written.
 - [ ] Integration tests pass (`npm run test:integration`).
-- [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
-- [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
 - [ ] Run site url through the Facebook debugger (https://developers.facebook.com/tools/debug/) to check it will appear correctly if shared.
-- [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink).
+- [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink) to find & fix broken links.
 
 ### Performance
 
-- [ ] All static assets (CSS, JS, SVG, JSON) are minified and concatenated in production.
-- [x] TODO - Single pages are less than the allocated performance budget (unless there's a very good reason not to).
-- [ ] Run through [Google PageSpeed](https://developers.google.com/speed/pagespeed/), [GTmetrix](https://gtmetrix.com/).
-- [x] TODO – Critical CSS is extracted and inlined in the HTML file if relevant.
+- [ ] The site has a score above 90 in [Google PageSpeed](https://developers.google.com/speed/pagespeed/) and [GTmetrix](https://gtmetrix.com/).
 - [ ] Web fonts should be kept to a minimum (talk with designers).
 - [ ] Subset webfonts to remove unused characters (http://www.subsetter.com/, https://github.com/miguelsousa/source-sans-pro-subset).
 - [ ] Font files are available in WOFF, WOFF2, and EOT/OTF if relevant (IE8 / Android Stock Browser).
 - [ ] Static files are cache-busted with a query parameter (eg. `?v=4hjk54j6`) in production (JS/CSS/etc).
+- [x] TODO - Single pages are less than the allocated performance budget (unless there's a very good reason not to).
+- [x] TODO – Critical CSS is extracted and inlined in the HTML file if relevant.
 
 ### Deployment
 
 - [ ] The project is [`shrinkwrapped`](https://github.com/springload/frontend-starter-kit/#adding-and-upgrading-dependencies) to pin its dependencies.
-- [ ] The build service / CI is using `NODE_ENV=production` for compilation tasks.
+- [ ] The build service / CI is using `NODE_ENV=production` for compilation tasks via the `npm run dist` command.
 - [ ] CI runs the CI tests (`npm run test:ci`, or `npm run test`), and the build breaks if they fail.
 
 ### Semantics

--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -22,7 +22,7 @@
 #### JS
 
 - [ ] JS code matches the code style guide via `npm run lint`.
-- [ ] JS code is written in ES6.
+- [ ] JS code is written in ES2015 (ES6), ES2016 (ES7), or later.
 - [ ] Data attributes are used to select elements, not classes or ids or tags.
 - [ ] Polyfills are included if appropriate (Respond.js, `fetch`, `babel-polyfill`, etc).
 

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -1,6 +1,6 @@
-# Frontend project launch checklist
+# Project launch checklist
 
-> Handy things to remember when launching a project.
+> Handy things to check when launching a project.
 
 > **This checklist is where we want to be**, not necessarily where we always are. Ideally we would want as many of those line items to already be taken care of by our starter kit and other boilerplates. In practice, it is not that simple and we need such a checklist to make sure that we deliver top-notch experiences.
 
@@ -16,198 +16,22 @@
 
 ## How to use this
 
-1. It will take you **around 2hours** to go through this list if you've done it before. Make sure you have the time. Ask for support.
-2. Open the [raw markdown version](https://raw.githubusercontent.com/springload/frontend-starter-kit/master/docs/launch-checklist.md), copy the content of the "FED Launch Checklist" section and paste it into a new GitHub issue on the relevant project.
-3. Move through the whole list and check items as you go.
-  - All of the items should be checked
-  - If an item is irrelevant it should be checked and a reason should be mentioned
-  - If an item cannot be tackled because of other constraints, backlog the problem and potential fix where appropriate
-  - If you've spotted/fixed something, take note of it in the same issue so that we can see the impact of this process on our ratio of bugs per project
-  - If you added new checklist items, consider adding them in the main checklist.
+1. It will take you **around 2 hours** to go through this list if you've done it before. Make sure you have the time. Ask for support.
+2. Open the [raw markdown files](https://raw.githubusercontent.com/springload/frontend-starter-kit/master/docs/launch-checklist.md), copy the content of the checklist sections and paste it into a new GitHub issue on the relevant project.
+3. In the GitHub issue, move through the whole list and check items as you go.
+  - All of the items should be checked.
+  - If an item is irrelevant it should be checked and a reason should be mentioned.
+  - If an item cannot be tackled because of other constraints, backlog the problem and potential fix where appropriate.
+  - If you've spotted/fixed something, take note of it in the same issue so that we can see the impact of this process on our ratio of bugs per project.
+  - If you added new checklist items, consider adding them back in the main checklists.
 
-## FED Launch Checklist
+## Checklists
 
-### Code quality
+|:heavy_check_mark:|
+|------------------|
+|[FED launch checklist](frontend-launch-checklist.md)|
+|Other checklists to be added here|
 
-- [ ] Clean up commented/unnecessary code
-- [ ] Check all TODO comments are still relevant
-- [ ] Debugging console logs and breakpoints removed
+### Other
 
-####  CSS
-
-- [ ] CSS code matches the code style guide via `npm run lint`
-- [ ] [CSS validation](http://jigsaw.w3.org/css-validator/) passes
-- [ ] CSS classes use a consistent naming methodology (BEM)
-- [ ] Flexbox usage has a non-flexbox fallback if appropriate
-- [ ] Sass code is free of vendor prefixes and IE filters
-- [x] TODO – CSS specificity graph is flat :rainbow:
-- [x] TODO – Print stylesheets exist if appropriate
-- [ ] Site does not use `-webkit-font-rendering: antialised;` for body copy
-
-#### JS
-
-- [ ] JS code matches the code style guide via `npm run lint`
-- [ ] JS code is written in ES6
-- [ ] Data attributes are used to select elements, not classes or ids or tags.
-- [ ] Polyfills are included if appropriate (Respond.js, `fetch`, `babel-polyfill`, etc)
-
-#### HTML
-
-- [ ] Ensure all `a` tags have an href attribute.
-- [ ] Use absolute paths for all URLS. `/thing/` not `thing/`
-- [ ] Use HTTPS, or exclude protocol from URLs `//foo.com/` not `http://foo.com/`
-- [ ] [HTML validation](https://validator.w3.org/nu/#textarea) passes
-- [ ] Links do not use `target="_blank"`, or use [`rel="noopener`](https://mathiasbynens.github.io/rel-noopener/) if they need to.
-
-#### Images
-
-- [ ] Images use the right file format (SVG if possible, PNG for graphics, JPG for pictures)
-- [ ] All images with the `img` tag define `width` and `height` attributes to prevent content reflows when the images load
-- [ ] Icons are built using [SVG icons](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/icon.html), with appropriate fallback if necessary
-- [ ] All of the images are [losslessly optimized with ImageOptim](https://imageoptim.com/)
-
-### Functional completeness
-
-- [ ] 404 page exists and is styled
-- [ ] 500 page exists and is styled
-- [ ] Maintenance page exists and is styled, if relevant
-- [ ] Site uses a mobile-friendly, zoomable viewport
-- [ ] Site has a favicon.ico
-- [ ] Platform-specific ([Apple](https://developer.apple.com/library/safari/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html), Android, Windows, etc) meta tags and favicons are added and checked with the [Favicon checker](https://realfavicongenerator.net/favicon_checker)
-- [ ] Ensure meta tags, Open Graph tags, Twitter card tags, and descriptions are set
-- [ ] Ensure the social meta tags only use a default sharing image if there is no page-specific image to use
-- [ ] Google Search Console / Webmaster Tools is configured on the project
-- [ ] Long-running actions (AJAX calls) trigger a spinner or other loading message in the UI.
-- [ ] UI text uses correct typographic marks (`’` instead of `'`, `“”` instead of `""`)
-- [ ] Significant UI states (tabs, modals, etc) should be tracked in the URL via query parameter or the hash.
-
-### Forms 
-
-- [ ] Form fields use the right [input types with the right mobile keyboard](http://baymard.com/labs/touch-keyboard-types)
-- [ ] Form fields have their [`name`, `autocomplete` and `autocorrect` attributes](https://html.spec.whatwg.org/multipage/forms.html#attr-fe-autocomplete) set correctly
-- [ ] Forms never trust client-side input, ensure it is valid
-- [ ] Prompt the user before navigating away from unsaved changes
-- [ ] Always re-populate fields when a user hits 'back', by using cache-control: private.
-- [ ] Multi-step forms save data after each step
-
-#### Form validation and errors
-
-- [ ] Forms use server-side validation, and client-side validation if relevant
-- [ ] Forms do not use HTML5 validation. No `required`. Field `type`, `maxlength` and other consistent improvements that do not need to display validation messages are ok. `minlength` isn't.
-- [ ] Form errors are cleared when people change a field's value
-- [ ] Forms display non-field errors at the top of the form
-- [ ] If there are no non-field errors, still display a message, eg “Sorry, there were some errors” at the top of the form
-- [ ] Forms use CSRF tokens when they mutate state (POST/PUT/DELETE, eg. editing a user/booking/listing’s data)
-
-#### Search
-
-- [ ] Use GETs with query strings for all kinds of searches (as query strings can be easily bookmarked).
-
-### Build systems
-
-- [ ] Use [Pleeease/Autoprefixer](http://pleeease.io) for all styles
-- [ ] No compiled code in the `master` branch
-- [ ] JS development aids are removed in production
-- [ ] Source maps are removed in production
-- [ ] SVG icons are compressed in production
-
-### Testing
-
-- [ ] Site is visually tested on non-retina, low contrast screens
-- [ ] Relevant unit tests are written
-- [ ] Unit tests pass (`npm run test:unit`)
-- [ ] Relevant integration tests are written
-- [ ] Integration tests pass (`npm run test:integration`)
-- [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
-- [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support) (including IE if relevant)
-- [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
-- [ ] Run site url through the Facebook debugger (https://developers.facebook.com/tools/debug/) to check it will appear correctly if shared.
-- [ ] Run the link checker [`hyperlink -r http://example.com/`](https://github.com/springload/frontend-starter-kit/blob/master/docs/useful-tooling.md#hyperlink)
-- [ ] Spelling and grammar checked thoroughly (copy/paste the site's content in Google Docs, or better yet get someone else on the team or from the client to do it for you)
-
-### Performance
-
-- [ ] All static assets (CSS, JS, SVG, JSON) are minified and concatenated in production
-- [x] TODO - Single pages are less than the allocated performance budget (unless there's a very good reason not to)
-- [ ] Run through [Google PageSpeed](https://developers.google.com/speed/pagespeed/), [GTmetrix](https://gtmetrix.com/)
-- [ ] Use [SpeedCurve](https://speedcurve.com) to configure the performance monitoring on the site's most important page (homepage?)
-- [x] TODO – Critical CSS is extracted and inlined in the HTML file if relevant
-- [ ] Web fonts should be kept to a minimum (talk with designers)
-- [ ] Subset webfonts to remove unused characters (http://www.subsetter.com/, https://github.com/miguelsousa/source-sans-pro-subset)
-- [ ] Font files are available in WOFF, WOFF2, and EOT/OTF if relevant (IE8 / Android Stock Browser)
-- [ ] Static files are cache-busted with a query parameter (eg. `?v=4hjk54j6`) in production (JS/CSS/etc)
-
-#### Server configuration
-
-- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with PageSpeed or GTmetrix)
-- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with PageSpeed or GTmetrix)
-- [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`)
-
-### Deployment
-
-- [ ] The project is [`shrinkwrapped`](https://github.com/springload/frontend-starter-kit/#adding-and-upgrading-dependencies) to pin its dependencies.
-- [ ] The build service / CI is using `NODE_ENV=production` for compilation tasks
-- [ ] No unnecessary files (`node_modules`) are sent to the production server, slowing down the build (look for the list of files sent to the server in the `rsync` step of the deployment)
-- [ ] CI runs the CI tests (`npm run test:ci`, or `npm run test`), and the build breaks if they fail
-- [ ] CI builds trigger notifications in the appropriate Slack channel.
-
-### Semantics
-
-- [ ] Relevant site sections use appropriate [schema.org](http://schema.org/) structured data (events, products, persons, etc), tested with https://search.google.com/structured-data/testing-tool.
-
-### SEO
-
-- [ ] Link to sitemap `<link rel=”sitemap” type=”application/xml” title=”Sitemap” href=”/sitemap.xml”>”`
-- [ ] Sitemap content is relevant
-- [ ] Help pagination with rel=”next” and rel=”prev” tag
-- [ ] robots.txt is here
-- [ ] humans.txt is here (forbidden in robots.txt)
-
-### Analytics
-
-- [ ] Google Tag Manager or Google Analytics are loaded on all pages (but not both)
-- [ ] Check analytics are configured in development with a development property
-- [ ] Check analytics are configured in production with the production property
-- [ ] Check the relevant client-side interactions are tracked with events
-- [ ] If relevant, client-side JS errors are logged as [exceptions](https://developers.google.com/analytics/devguides/collection/analyticsjs/exceptions)
-- [ ] Page and event tracking is being displayed correctly in the GA dashboard.
-
-### Accessibility
-
-- [ ] Roles are assigned to basic site sections
-header - `role="banner"`, main content - `role="main"`, footer - `role="contentinfo"`
-- [ ] All images must have appropriate alt tags - extra great if you include all text that appears eg English and Māori translation text in a lot of company logos in NZ. [empty `alt=""` can be appropriate](http://osric.com/chris/accidental-developer/2012/01/when-should-alt-text-be-blank/)
-- [ ] If relevant, icons include an accessible label with the `<title>` SVG tag
-- [ ] `<html>` element has attribute `lang="en-nz"`
-- [ ] If you have used outline: 0 anywhere make sure you have called the tab focus function in utils js file or any other alternative style for focus state.
-- [ ] Screen reader only text for links with images/icons only
-- [ ] Form fields are inside the label element
-- [ ] Form error messages should be inside label element
-- [ ] All toggle content should have aria controls and expanded states
-- [ ] Most important content and pages are tested for color-blindness and vision disorders with http://lowvision.support/
-- [ ] Body copy and visuals have enough contrast according to WCAG guidelines https://leaverou.github.io/contrast-ratio/
-
-### Documentation
-
-- [ ] The code documents itself via function names and variable names
-- [ ] The code contains comments to explain its intent where appropriate
-
-#### The README contains
-
-- [ ] Continuous integration service badge for the project (CodeShip)
-- [ ] A table of important links with,
-- [ ] Stage and Live site links
-- [ ] Links to Trello board, Harvest project, project run sheet, Drive folder
-- [ ] Links to design resources - Zeplin, InVision, other
-- [ ] Analytics and montoring URLs
-- [ ] Links to other important documents and services
-- [ ] Project installation instructions
-- [ ] Project development commands
-- [ ] Test commands
-- [ ] Deployment commands
-- [ ] [Browser support definition](https://github.com/springload/frontend-starter-kit#browser-support)
-- [ ] The project's useful patterns to reuse
-- [ ] Debugging tricks
-- [ ] Testing data
-
-You made it to the end! Whoo, high five my friend :pray:! Now go treat yourself to a drink :tropical_drink:, a hug :hugging_face:, or whatever floats your boat :rainbow:. Don’t forget to let your team know that you’ve got this under control, and be proud of that top-notch site you just built. :metal:
+### Other bis

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -17,21 +17,68 @@
 ## How to use this
 
 1. It will take you **around 2 hours** to go through this list if you've done it before. Make sure you have the time. Ask for support.
-2. Open the [raw markdown files](https://raw.githubusercontent.com/springload/frontend-starter-kit/master/docs/launch-checklist.md), copy the content of the checklist sections and paste it into a new GitHub issue on the relevant project.
+2. Open the [raw markdown files](#checklists), copy the content of the checklist sections and paste it into a new GitHub issue on the relevant project.
 3. In the GitHub issue, move through the whole list and check items as you go.
   - All of the items should be checked.
   - If an item is irrelevant it should be checked and a reason should be mentioned.
   - If an item cannot be tackled because of other constraints, backlog the problem and potential fix where appropriate.
   - If you've spotted/fixed something, take note of it in the same issue so that we can see the impact of this process on our ratio of bugs per project.
   - If you added new checklist items, consider adding them back in the main checklists.
+4. Once you are done, ping your front-end lead (`@username` on GitHub) to let them know this is done so they can help with what is left.
 
 ## Checklists
 
-|:heavy_check_mark:|
-|------------------|
-|[FED launch checklist](frontend-launch-checklist.md)|
-|Other checklists to be added here|
+|:heavy_check_mark:|Raw file|
+|------------------|--------|
+|[Front-end launch checklist](frontend-launch-checklist.md)|[frontend-launch-checklist.md](https://raw.githubusercontent.com/springload/frontend-starter-kit/master/docs/frontend-launch-checklist.md)|
+|[Project best practices](#project-best-practices)|[launch-checklist.md](https://raw.githubusercontent.com/springload/frontend-starter-kit/master/docs/launch-checklist.md)|
 
-### Other
+### Project best practices
 
-### Other bis
+#### Images
+
+- [ ] All of the images are [losslessly optimized with ImageOptim](https://imageoptim.com/).
+
+#### SEO
+
+- [ ] Link to sitemap `<link rel=”sitemap” type=”application/xml” title=”Sitemap” href=”/sitemap.xml”>”`.
+- [ ] Sitemap content is relevant.
+- [ ] robots.txt is here.
+- [ ] humans.txt is here (forbidden in robots.txt).
+
+#### Tests
+
+- [ ] Spelling and grammar checked thoroughly (copy/paste the site's content in Google Docs, or better yet get someone else on the team or from the client to do it for you).
+
+#### Monitoring
+
+- [ ] Use [SpeedCurve](https://speedcurve.com) to configure the performance monitoring on the site's most important page (homepage?).
+- [ ] [Google Search Console / Webmaster Tools](https://www.google.com/webmasters/tools) is configured on the project.
+
+#### Server configuration
+
+- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with PageSpeed or GTmetrix).
+- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with PageSpeed or GTmetrix).
+- [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`).
+
+#### Deployment
+
+- [ ] No unnecessary files (`node_modules`) are sent to the production server, slowing down the build (look for the list of files sent to the server in the `rsync` step of the deployment).
+- [ ] CI builds trigger notifications in the appropriate Slack channel.
+
+#### Fonts
+
+- [ ] All of the fonts used on the project are correctly licensed, at the appropriate license level (expected pageviews/month).
+- [ ] If relevant, Analytics email alerts are set up when audience levels go over the fonts' license thresholds.
+
+#### Documentation
+
+#### The README contains
+
+- [ ] Continuous integration service badge for the project (CodeShip).
+- [ ] All of the important links as a table.
+- [ ] Stage and Live site links.
+- [ ] Links to Trello board, Harvest project, project run sheet, Drive folder.
+- [ ] Links to design resources - Zeplin, InVision, other.
+- [ ] Analytics and other monitoring URLs.
+- [ ] Links to other important documents and services.

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -55,12 +55,12 @@
 #### Monitoring
 
 - [ ] Use [SpeedCurve](https://speedcurve.com) to configure the performance monitoring on the site's most important page (homepage?).
-- [ ] [Google Search Console / Webmaster Tools](https://www.google.com/webmasters/tools) is configured on the project.
+- [ ] [Google Search Console / Webmaster Tools](https://www.google.com/webmasters/tools) is configured on the live site.
 
 #### Server configuration
 
-- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)).
-- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)).
+- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)) on the live site.
+- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)) on the live site.
 - [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`).
 
 #### Deployment

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -45,8 +45,8 @@
 
 - [ ] Link to sitemap `<link rel=”sitemap” type=”application/xml” title=”Sitemap” href=”/sitemap.xml”>”`.
 - [ ] Sitemap content is relevant.
-- [ ] robots.txt is here.
-- [ ] humans.txt is here (forbidden in robots.txt).
+- [ ] `/robots.txt` is here.
+- [ ] `/humans.txt` is here (Disallowed in robots.txt).
 
 #### Tests
 
@@ -59,8 +59,8 @@
 
 #### Server configuration
 
-- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with PageSpeed or GTmetrix).
-- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with PageSpeed or GTmetrix).
+- [ ] Static files are gzipped in production (JS/CSS/SVG/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)).
+- [ ] Static files are cached for a long time in production (JS/CSS/images/etc, check this with [PageSpeed](https://developers.google.com/speed/pagespeed/insights/) or [GTmetrix](https://gtmetrix.com/)).
 - [ ] Canonical URL redirect exists, if relevant (`example.com` ➞ `www.example.com`).
 
 #### Deployment

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -1,6 +1,6 @@
 # Project launch checklist
 
-> Handy things to check when launching a project.
+> Handy things to check when building a website or web app.
 
 > **This checklist is where we want to be**, not necessarily where we always are. Ideally we would want as many of those line items to already be taken care of by our starter kit and other boilerplates. In practice, it is not that simple and we need such a checklist to make sure that we deliver top-notch experiences.
 
@@ -15,6 +15,8 @@
 ```
 
 ## How to use this
+
+> This is meant to be used when a site goes live, but do go through it sooner to make sure there won't be too many surprises.
 
 1. It will take you **around 2 hours** to go through this list if you've done it before. Make sure you have the time. Ask for support.
 2. Open the [raw markdown files](#checklists), copy the content of the checklist sections and paste it into a new GitHub issue on the relevant project.

--- a/docs/launch-checklist.md
+++ b/docs/launch-checklist.md
@@ -50,6 +50,7 @@
 
 #### Tests
 
+- [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support) by multiple people, including the client.
 - [ ] Spelling and grammar checked thoroughly (copy/paste the site's content in Google Docs, or better yet get someone else on the team or from the client to do it for you).
 
 #### Monitoring


### PR DESCRIPTION
Let’s make the launch checklist more relevant by:

- [x] Making it clear that while it's a "launch" checklist, it's useful to go through it earlier on
- Reviewing what it contains together, so that for each item we:
  - [x] Understand what it's about, and what are the implications.
  - [x] Understand how to assess it.
  - [x] Document items that aren't clear enough.
  - [x] Make sure it is a FED thing. Otherwise we can have it around but not in the main "FED" list.
  - [x] Check if it could be done (semi-)automatically?
  - [x] For things that are done automatically, add a note or link of where in the starter kit these things are happening? So we can quickly check our project is set up correctly.
  - [x] Know if the check/action requires the site to be live in order to be done (eg. Google Search Console).