### PR TITLE
Remove greenkeeper shrinkwrap support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,12 @@ cache:
   - node_modules
 node_js:
 - 6
-before_install:
-- npm install -g greenkeeper-shrinkwrap@1
 install:
 - npm install
 - npm install -g david hyperlink coveralls
-before_script:
-- greenkeeper-shrinkwrap-update
 script:
 - npm run dist
 - npm run test:ci
-after_script:
-- greenkeeper-shrinkwrap-upload
 after_success:
 - cat ./coverage/lcov.info | coveralls
 branches:


### PR DESCRIPTION
Does not seem to work as intended. This will force us to update shrinkwraps manually, but that feels like a minor drawback.

If/when we switch to yarn, we will have to revisit anyway.