### PR TITLE
removing css validator, rendering to smoothing

### DIFF
--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -11,13 +11,12 @@
 ####  CSS
 
 - [ ] CSS code matches the code style guide via `npm run lint`.
-- [ ] [CSS validation](http://jigsaw.w3.org/css-validator/) passes.
 - [ ] CSS classes use a consistent naming methodology (BEM).
 - [ ] Flexbox usage has a non-flexbox fallback if appropriate.
 - [ ] Sass code is free of vendor prefixes and IE filters.
 - [x] TODO – CSS specificity graph is flat :rainbow:.
 - [ ] Print styles are defined.
-- [ ] Site does not use `-webkit-font-rendering: antialised;` for body copy.
+- [ ] Site does not use `-webkit-font-smoothing: antialised;` for body copy.
 - [ ] The filename of the root level stylesheet is `styles.scss`, unless there are multiple root-level stylesheets.
 
 #### JS


### PR DESCRIPTION
Removing the CSS validator, it's a bit flawed and our linting should cover this
Changing `webkit-font-rendering` to `webkit-font-smoothing` because thats what it is actually called. 