### PR TITLE
Add report:build command producing Webpack stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ coverage
 .grunt
 .bundle
 docs/pattern-library/index.html
+webpack-stats.json
 
 # -------------------------------------------------
 # Dependency directories

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "critical:css": "gulp critical:css",
     "report:css": "gulp report:css",
     "report:coverage": "open coverage/lcov-report/index.html",
+    "report:build": "NODE_ENV=production webpack --config webpack/webpack.config.prod.js --profile --json > webpack-stats.json",
     "js": "gulp js",
     "css": "gulp css",
     "svg": "gulp svg",


### PR DESCRIPTION
This will be useful on an increasing number of our projects, since we now use Webpack everywhere.

This command produces a JSON file containing Webpack bundle statistics.

At the moment I'm using https://github.com/th0r/webpack-bundle-analyzer to produce a visualisation of a project's bundle. Here is what it looks like for the starter kit:

![webpack-bundle-analyzer](https://user-images.githubusercontent.com/877585/27030986-13a15622-4f77-11e7-9096-dec51eeb6e05.png)

I'm not sure yet this is the best tool, and it's for one-off audits, so it's not built-in for now.