### PR TITLE
Enable tree shaking via Webpack 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
               "> 1%",
               "IE 11"
             ]
-          }
+          },
+          "modules": false
         }
       ],
       "react"


### PR DESCRIPTION
Webpack 2 now supports ES modules, which means we can turn off Babel transforming them into CommonJS modules. Practically, this means that we can do [tree shaking](https://webpack.js.org/guides/tree-shaking/) and reduce our build size without any further change.

In our build, this only shaves off 1.4kb but that's still 10% of the default JS file.

NB: I also tried turning on `loose` mode and the improvement was very small, so will reserve this for projects that want to optimise further – and have the time to debug the potential issues incurred.