### PR TITLE
Tweak autoprefixer config to target more browsers

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -23,13 +23,12 @@ module.exports = {
 
     PlzOptions: {
         minifier: prod,
+        // See http://pleeease.io/docs/#mqpacker
         mqpacker: false,
+        // See http://pleeease.io/docs/#filters
         filters: false,
-        rem: true,
-        pseudoElements: true,
-        opacity: true,
         autoprefixer: {
-            browsers: ['ie 8', 'ie 9', '> 1%'],
+            browsers: ['> 0.1%'],
         },
     },
 };


### PR DESCRIPTION
This increases the number of browser prefixes being added, and only increases the build by a hundred bytes on a large-scale CSS codebase, so I think it's worth having "as much support as possible" as the default.

Not having references to any browsers in here also makes it more apparent that there is no direct relation between which browsers are supported, and which browsers get prefixed CSS.

Note that for projects with specific needs / performance targets, it will still be worth customising this on a case by case basis.