### PR TITLE
Add adblock checklist item

### DIFF
--- a/docs/frontend-launch-checklist.md
+++ b/docs/frontend-launch-checklist.md
@@ -99,6 +99,7 @@
 
 - [ ] Site tested in [all relevant browsers and devices](https://github.com/springload/frontend-starter-kit/tree/master/docs#browser--device-support).
 - [ ] Site is visually tested on non-retina, low contrast screens.
+- [ ] Site works with adblock extensions activated.
 - [ ] Site works with JavaScript turned off, or the sections that do not work are [indicated to the user via messages in `<noscript>` tags](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/enable-javascript.html), styled according to the site's branding.
 - [ ] ['Upgrade your browser'](https://github.com/springload/frontend-starter-kit/blob/master/core/templates/core/snippets/outdated-browser.html) message displayed on unsupported browsers.
 


### PR DESCRIPTION
@vincentaudebert, @MichelleKennedy and I just spent 1h trying to understand a rendering difference between our computers/environments.

Turns out this was because of the href of a link, which was pointing to a `ad.doubleclick.net` URL for tracking purposes, which is blocked by adblock-ers. Kudos to @MichelleKennedy for finding this 😉 .

We should check this on all sites at go-live, because even though we do not work with that many ad-heavy sites those issues do pop up and they can be hard to track down.