### PR TITLE
Remove 'todo'

### DIFF
--- a/django-wagtail/README.md
+++ b/django-wagtail/README.md
@@ -35,7 +35,6 @@ Note: To learn how to write JavaScript or import Sass files from JavaScript is a
 
 # Future Improvements?
 
-* Production build minification.
 * ...your idea goes here
 
 ## Project Files


### PR DESCRIPTION
Minification (Uglification) is enabled by default when you run webpack with the flat `mode=production`, which we are doing.