### PR TITLE
Chore/bump html webpack plugin

### DIFF
--- a/django-wagtail/package.json
+++ b/django-wagtail/package.json
@@ -27,7 +27,7 @@
     "cssnano": "^3.10.0",
     "eslint": "^4.9.0",
     "eslint-plugin-springload": "^2.2.0",
-    "html-webpack-plugin": "^3.0.7",
+    "html-webpack-plugin": "^3.2.0",
     "node-sass": "^4.8.3",
     "postcss-loader": "^2.1.4",
     "prettier": "^1.12.0",

--- a/django-wagtail/yarn.lock
+++ b/django-wagtail/yarn.lock
@@ -3130,7 +3130,7 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.3.x"
 
-html-webpack-plugin@^3.0.7:
+html-webpack-plugin@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
   dependencies:


### PR DESCRIPTION
The incumbent version of `html-webpack-plugin` was not compatible with `webpack@4` and required a bump to `3.2` to fix this incompatibility.