### PR TITLE
Closes #123: Typo for accessibility link in HTML general docs

### DIFF
--- a/docs/html.md
+++ b/docs/html.md
@@ -16,7 +16,7 @@ Refer to our [prettier config](https://github.com/springload/prettier-config-spr
 
 Aside from CSS colours, HTML is primarily responsible for making accessible webpages (regardless of whether you're generating HTML from Django/Wagtail or React etc.).
 
-Go read Sam's [Being pragmatic about accessibility](https://www.springload.co.nz/blog/pragmatic-about-accessibility/).
+Go read Sam's [Being pragmatic about accessibility](https://www.springload.co.nz/blog/being-pragmatic-about-accessibility/).
 
 ### Accessibility Reading
 - https://github.com/Heydon/inclusive-design-checklist


### PR DESCRIPTION
PR fixes a small typo for the link to a blog post in the HTML docs