### PR TITLE
Update frontend-checklist.md

### DIFF
--- a/docs/frontend-checklist.md
+++ b/docs/frontend-checklist.md
@@ -77,7 +77,6 @@ header - `role="banner"`, main content - `role="main"`, footer - `role="contenti
   - [ ] Forms and/or fields should have accessible validation messages. [Ensure Server-side Errors are Accessible](https://www.washington.edu/accessibility/checklist/form-validation/).
   - [ ] All images must have appropriate alt tags - extra great if you include all text that appears. Eg. English and Māori translation text in a lot of company logos in NZ. [empty `alt=""` can be appropriate](http://osric.com/chris/accidental-developer/2012/01/when-should-alt-text-be-blank/).
   - [ ] Ensure any acronyms/abbreviations use the `<abbr>` tag.
-- [ ] Pagination with `rel=”next”` and `rel=”prev”` attributes.
 - [ ] Test all templates/components with the axe plugin (including states like modal open, megamenu open). Fix all errors.
 
 ## Fonts


### PR DESCRIPTION
`Pagination with `rel=”next”` and `rel=”prev”` attributes.`

From what I can tell, this isn't needed. 

To be clear (because it wasn't clear), this seems to be a `<head>` element, not something you put on your in-page pagination links. i.e.:
```
<head>
  <link rel="prev" href="some-other-webpage.html">
```

It used to be used as an SEO thing, but a) google stopped supporting this YEARS ago and b) we don't tend to build pages like this.