### PR TITLE
Hard coded url

### DIFF
--- a/docs/frontend-checklist.md
+++ b/docs/frontend-checklist.md
@@ -15,7 +15,7 @@ Some items may make more sense to be checked by a tester, backender or ops perso
 - [ ] Project installation instructions.
 - [ ] Links to all deploy environments and any associated Git branch names.
 - [ ] Links to CI, Jira/Trello, Harvest project, project run sheet, Google Drive folder, Figma/Zeplin, other.
-- [ ] Expected Browser support and accessibility support. Copy [browser-device-support.md](./browser-device-support.md) into your README.md and modify to suit.
+- [ ] Expected Browser support and accessibility support. Copy [browser-device-support.md](https://github.com/springload/frontend-starter-kit/blob/main/docs/browser-device-support.md) into your README.md and modify to suit.
 - [ ] Any debugging tricks or quirks that might be useful for future devs.
 
 ## Project structure


### PR DESCRIPTION
when copy pasting the URL points to a relative path. Adding it as a hard coded path, it'll be linking to the correct file.